### PR TITLE
Optimize image size and container startup time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir flask flask_json
 
 RUN mkdir -p falsefriends
-COPY ./ /falsefriends
+COPY requirements.txt /falsefriends/
 WORKDIR /falsefriends/
 RUN python --version && \
     pip install --no-cache-dir Cython==0.29.32 && \
@@ -36,5 +36,5 @@ RUN mkdir falsefriendsp/resources/big \
 
 EXPOSE 8866
 
-#COPY ./ ./
+COPY ./ ./
 CMD ["python", "serve.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
 FROM python:3.5
 
-RUN apt-get update -y \
-	&& apt-get install -y python3-pip python3-dev \
-    && apt-get install -y wget \
-	&& apt-get install -y bzip2 \
-    && apt-get install -y unzip \
-	&& rm -rf /var/lib/apt/lists/*
-
 RUN pip install --upgrade pip && \
     pip install nltk && \
     pip install flask flask_json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.5 AS base
 
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir flask flask_json
@@ -16,25 +16,40 @@ ENV LANG="C.UTF-8" \
 
 RUN wget https://github.com/pln-fing-udelar/false-friends/archive/refs/heads/master.zip \
 	&& unzip master.zip \
+        && rm master.zip \
     && mv false-friends-master falsefriendsp \
     && touch falsefriendsp/__init__.py
 
 RUN python -m nltk.downloader wordnet \
     && python -m nltk.downloader omw
 
+## fork build here - create a temporary stage to pre-process the models
+FROM base as modelbuilder
 
-##download models
-RUN wget http://cs.famaf.unc.edu.ar/~ccardellino/SBWCE/SBW-vectors-300-min5.txt.bz2 \
-    && bzip2 -d SBW-vectors-300-min5.txt.bz2
+##download models and store in build cache
+RUN mkdir model-data \
+    && wget --progress=dot:giga -O model-data/es.txt.bz2 http://cs.famaf.unc.edu.ar/~ccardellino/SBWCE/SBW-vectors-300-min5.txt.bz2
 
-RUN wget http://143.107.183.175:22980/download.php?file=embeddings/word2vec/skip_s300.zip \
-    && unzip download.php?file=embeddings%2Fword2vec%2Fskip_s300.zip
+RUN wget --progress=dot:giga -O model-data/skip_s300.zip http://143.107.183.175:22980/download.php?file=embeddings/word2vec/skip_s300.zip \
+    && cd model-data && unzip skip_s300.zip skip_s300.txt && rm skip_s300.zip
 
-RUN mkdir falsefriendsp/resources/big \
-    && mv SBW-vectors-300-min5.txt falsefriendsp/resources/big/es.txt \
-    && mv skip_s300.txt falsefriendsp/resources/big/pt.txt
+# pre-compile model files into fast-loading KeyedVectors format
+COPY buildscripts/w2v_to_kv.py buildscripts/
+
+RUN mkdir model-files && python buildscripts/w2v_to_kv.py model-data/es.txt.bz2 model-files/es.kv
+RUN python buildscripts/w2v_to_kv.py model-data/skip_s300.txt model-files/pt.kv
+
+# pre-compile linear transform and training pairs and save in npz format
+COPY buildscripts/build_linear_trans.py buildscripts/
+RUN PYTHONPATH=/falsefriends python buildscripts/build_linear_trans.py model-files/es.kv model-files/pt.kv model-files/trans_es_300_pt_300.npz \
+      model-files/training_pairs.npz
+
+## go back to the fork point and copy just the final compiled files into the runtime image
+FROM base AS runtime
 
 EXPOSE 8866
 
-COPY ./ ./
+COPY --from=modelbuilder /falsefriends/model-files/ ./falsefriendsp/resources/big/
+
+COPY serve.py ./
 CMD ["python", "serve.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.5
 
 RUN pip install --upgrade pip && \
-    pip install nltk && \
     pip install flask flask_json
 
 RUN mkdir -p falsefriends

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM python:3.5
 
-RUN pip install --upgrade pip && \
-    pip install flask flask_json
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir flask flask_json
 
 RUN mkdir -p falsefriends
 COPY ./ /falsefriends
 WORKDIR /falsefriends/
 RUN python --version && \
-    pip install Cython && \
-    pip install -r requirements.txt
+    pip install --no-cache-dir Cython==0.29.32 && \
+    pip install --no-cache-dir -r requirements.txt
 
 
 ENV LANG="C.UTF-8" \

--- a/buildscripts/build_linear_trans.py
+++ b/buildscripts/build_linear_trans.py
@@ -1,0 +1,30 @@
+from gensim.models import KeyedVectors
+from falsefriendsp.falsefriends import word_vectors, linear_trans, bilingual_lexicon, classifier
+import numpy as np
+import sys
+
+
+def read_words(file_name):
+    with open(file_name) as friends_file:
+        friend_pairs = []
+        for line in friends_file.readlines():
+            word_es, word_pt, true_friends = line.split()
+            if true_friends != '-1':
+                true_friends = true_friends == '1'
+                friend_pairs.append(classifier.FriendPair(word_es, word_pt, true_friends))
+    return friend_pairs
+
+
+model_es = KeyedVectors.load(sys.argv[1])
+model_pt = KeyedVectors.load(sys.argv[2])
+
+lexicon = bilingual_lexicon.bilingual_lexicon()
+X, Y = zip(*word_vectors.bilingual_lexicon_vectors(model_es, model_pt, bilingual_lexicon=lexicon))
+T = linear_trans.linear_transformation(X, Y)
+linear_trans.save_linear_transformation(sys.argv[3], T)
+
+training_friend_pairs = read_words(
+    "./falsefriendsp/resources/sepulveda2011_training.txt")
+
+X_train, y_train = classifier.features_and_labels(training_friend_pairs, model_es, model_pt, T)
+np.savez(sys.argv[4], X_train=X_train, y_train=y_train)

--- a/buildscripts/w2v_to_kv.py
+++ b/buildscripts/w2v_to_kv.py
@@ -1,0 +1,5 @@
+from gensim.models import KeyedVectors
+import sys
+
+model = KeyedVectors.load_word2vec_format(sys.argv[1])
+model.save(sys.argv[2])


### PR DESCRIPTION
The current docker approach has a number of shortcomings that make the image much larger than it needs to be, and cause it to take several minutes from container launch to being ready to serve requests.

The `Dockerfile` downloads some large files in one step:

https://github.com/Gradiant/elg_falsefriends/blob/301df36c78d239f1a28f39d827ccf71270d90567/Dockerfile#L35-L39

and then moves them to another directory in a subsequent step:

https://github.com/Gradiant/elg_falsefriends/blob/301df36c78d239f1a28f39d827ccf71270d90567/Dockerfile#L41-L43

This is very inefficient because of the way layers work in a Docker image, and means that the final image will contain the large file data _twice_, once in the original location in one layer and again in the moved location in the next layer.

The slow container startup is due to the fact that `serve.py` builds the `KeyedVectors` models from the raw word2vec data and calculates other derived data structures every time the container starts.  Parsing the word2vec text format is extremely slow, and it can take several minutes to complete the loading process.  However `KeyedVectors` has its own native on-disk serialization format that is much faster to load.

This PR addresses both these issues by "pre-compiling" the data structures, i.e. doing the conversion from word2vec to native `KeyedVectors` format as part of the image _build_ rather than the container startup.  For good measure the build now also pre-compiles the linear transformation and training vectors and stores their compiled form on disk.  This means that image build can take upwards of ten minutes, but then at runtime `serve.py` can simply load the pre-compiled files rather than having to compute the structures from the raw data, which brings the launch-to-ready time down from four or five minutes to less than ten seconds.

I've structured it as a multi-stage build so only the final compiled files are copied into the runtime image (the `.kv` files for the two models and the associated `.npy`/`.npz` files for the other vectors).  These files are in fact smaller than the original raw data files, and because they are not duplicated in several layers the resulting image is quite a bit smaller than the previous version.